### PR TITLE
fix header name

### DIFF
--- a/src/withdrawal/keymanagerAPIMessages.js
+++ b/src/withdrawal/keymanagerAPIMessages.js
@@ -25,7 +25,7 @@ async function requestValidatorSignature(keymanagerUrl, body) {
 
 	const response = await axiosInstance.post(keymanagerUrl, body, {
 		headers: {
-			"Аccept": "application/json",
+			"Accept": "application/json",
 			"Content-Type": "application/json",
 		},
 		validateStatus: (status) => {


### PR DESCRIPTION
When Accept is capitalized it gives me an error.
```
Header name must be a valid HTTP token ["Аccept"]
```